### PR TITLE
Improve daily report

### DIFF
--- a/daily.go
+++ b/daily.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"bytes"
-	"fmt"
+	"regexp"
 	"time"
 
-	"github.com/google/go-github/github"
 	"github.com/spf13/cobra"
 )
+
+var regexRepo = regexp.MustCompile("github\\.com\\/([^\\/]+\\/[^\\/]+)\\/")
 
 func newDailyCommand() *cobra.Command {
 	m := &cobra.Command{
@@ -20,46 +21,36 @@ func newDailyCommand() *cobra.Command {
 	return m
 }
 
-func plainFormatIssue(issue github.Issue) string {
-	s := fmt.Sprintf("%s %s", issue.GetHTMLURL(), issue.GetTitle())
+func formatDailyInactiveOnCalls(buf *bytes.Buffer) {
 
-	if issue.Assignees != nil {
-		for _, assigne := range issue.Assignees {
-			s += fmt.Sprintf(" @%s", assigne.GetLogin())
-		}
-	}
-
-	return s
-}
-
-func plainFormatIssues(buf *bytes.Buffer, title string, issues []github.Issue) {
-	if len(issues) == 0 {
-		return
-	}
-
-	buf.WriteString(fmt.Sprintf("# %s\n", title))
-
-	for _, issue := range issues {
-		buf.WriteString(fmt.Sprintf("+ %s\n", plainFormatIssue(issue)))
-	}
 }
 
 func runDailyCommandFunc(cmd *cobra.Command, args []string) {
-	now := time.Now()
-	start := now.Add(-24 * time.Hour).Format(dayFormat)
-	end := now.Format(dayFormat)
+	now := time.Now().UTC()
+	start := now.Add(-24 * time.Hour).Format(githubUTCDateFormat)
 
 	var buf bytes.Buffer
-	issues := getCreatedIssues(start, end)
-	plainFormatIssues(&buf, "New Issues", issues)
+	buf.WriteString("\n")
 
-	issues = getCreatedPullRequests(start, end)
-	plainFormatIssues(&buf, "New Pull Requests", issues)
+	issues := getCreatedIssues(start, nil)
+	formatSectionForSlackOutput(&buf, "New Issues", "New issues in last 24 hours")
+	formatGitHubIssuesForSlackOutput(&buf, issues)
+	buf.WriteString("\n")
 
-	msg := buf.String()
-	if len(msg) == 0 {
-		return
-	}
+	issues = getCreatedPullRequests(start, nil)
+	formatSectionForSlackOutput(&buf, "New Pull Requests", "New PRs in last 24 hours")
+	formatGitHubIssuesForSlackOutput(&buf, issues)
+	buf.WriteString("\n")
+
+	oncallIssues := queryJiraIssues("project = ONCALL AND created >= \"-1d\"")
+	formatSectionForSlackOutput(&buf, "New OnCalls", "New on calls in last 24 hours")
+	formatJiraIssuesForSlackOutput(&buf, oncallIssues)
+	buf.WriteString("\n")
+
+	oncallIssues = queryJiraIssues("project = ONCALL AND priority = Highest AND resolution = Unresolved AND updated <= \"-3d\"")
+	formatSectionForSlackOutput(&buf, "Inactive OnCalls", "Highest priority on calls inactive >= 3 days")
+	formatJiraIssuesForSlackOutput(&buf, oncallIssues)
+	buf.WriteString("\n")
 
 	sendToSlack(buf.String())
 }

--- a/daily.go
+++ b/daily.go
@@ -21,16 +21,12 @@ func newDailyCommand() *cobra.Command {
 	return m
 }
 
-func formatDailyInactiveOnCalls(buf *bytes.Buffer) {
-
-}
-
 func runDailyCommandFunc(cmd *cobra.Command, args []string) {
 	now := time.Now().UTC()
 	start := now.Add(-24 * time.Hour).Format(githubUTCDateFormat)
 
 	var buf bytes.Buffer
-	buf.WriteString("\n")
+	buf.WriteString(".\n")
 
 	issues := getCreatedIssues(start, nil)
 	formatSectionForSlackOutput(&buf, "New Issues", "New issues in last 24 hours")

--- a/jira.go
+++ b/jira.go
@@ -119,3 +119,11 @@ func updateSprint(sprintID int, args map[string]string) jira.Sprint {
 
 	return *responseSprint
 }
+
+func queryJiraIssues(jql string) []jira.Issue {
+	issues, _, err := jiraClient.Issue.Search(jql, &jira.SearchOptions{
+		MaxResults: 1000,
+	})
+	perror(err)
+	return issues
+}

--- a/main.go
+++ b/main.go
@@ -79,6 +79,8 @@ func initGlobal() {
 	tc := oauth2.NewClient(globalCtx, ts)
 	githubClient = github.NewClient(tc)
 
+	initTeamMembers()
+
 	jiraTransport := jira.BasicAuthTransport{
 		Username: config.Jira.User,
 		Password: config.Jira.Password,

--- a/slack.go
+++ b/slack.go
@@ -1,9 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
+	"strings"
 
+	"github.com/andygrunwald/go-jira"
+	"github.com/google/go-github/github"
 	"github.com/nlopes/slack"
+	"github.com/nlopes/slack/slackutilsx"
 )
 
 func sendToSlack(format string, args ...interface{}) {
@@ -28,8 +33,72 @@ func sendToSlack(format string, args ...interface{}) {
 	api := slack.New(token)
 	_, _, err := api.PostMessage(channelName,
 		slack.MsgOptionUser(user),
-		slack.MsgOptionText(fmt.Sprintf(format, args...), true))
+		slack.MsgOptionText(fmt.Sprintf(format, args...), false))
 	if err != nil {
 		perror(fmt.Errorf("can not post msg to slack with err: %v", err))
+	}
+}
+
+func formatSectionForSlackOutput(buf *bytes.Buffer, title string, description string) {
+	buf.WriteString(fmt.Sprintf("*%s*\n", slackutilsx.EscapeMessage(title)))
+	buf.WriteString(fmt.Sprintf("> %s\n", slackutilsx.EscapeMessage(description)))
+}
+
+func formatGitHubIssueForSlackOutput(issue github.Issue) string {
+	isFromTeam := false
+	login := issue.GetUser().GetLogin()
+	for _, id := range allMembers {
+		if strings.EqualFold(id, login) {
+			isFromTeam = true
+			break
+		}
+	}
+	var tp string
+	if !isFromTeam {
+		tp = " _(Community)_"
+	}
+
+	s := fmt.Sprintf("[ %s ]%s <%s|%s> by @%s", regexRepo.FindStringSubmatch(issue.GetHTMLURL())[1], tp, issue.GetHTMLURL(), slackutilsx.EscapeMessage(issue.GetTitle()), issue.GetUser().GetLogin())
+
+	if issue.Assignees != nil && len(issue.Assignees) > 0 {
+		s += fmt.Sprintf(", assigned to")
+		for _, assigne := range issue.Assignees {
+			s += fmt.Sprintf(" @%s", assigne.GetLogin())
+		}
+	}
+
+	return s
+}
+
+func formatJiraIssueForSlackOutput(issue jira.Issue) string {
+	link := fmt.Sprintf("%sbrowse/%s", config.Jira.Endpoint, issue.Key)
+	status := "Unknown"
+	if issue.Fields != nil && issue.Fields.Status != nil {
+		status = issue.Fields.Status.Name
+	}
+	priority := "Unknown"
+	if issue.Fields != nil && issue.Fields.Priority != nil {
+		priority = issue.Fields.Priority.Name
+	}
+	return fmt.Sprintf("[ %s / %s ] <%s|%s>", status, priority, link, issue.Fields.Summary)
+}
+
+func formatGitHubIssuesForSlackOutput(buf *bytes.Buffer, issues []github.Issue) {
+	if len(issues) == 0 {
+		buf.WriteString("_None_\n")
+		return
+	}
+	for _, issue := range issues {
+		buf.WriteString(fmt.Sprintf("• %s\n", formatGitHubIssueForSlackOutput(issue)))
+	}
+}
+
+func formatJiraIssuesForSlackOutput(buf *bytes.Buffer, issues []jira.Issue) {
+	if len(issues) == 0 {
+		buf.WriteString("_None_\n")
+		return
+	}
+	for _, issue := range issues {
+		buf.WriteString(fmt.Sprintf("• %s\n", formatJiraIssueForSlackOutput(issue)))
 	}
 }

--- a/slack.go
+++ b/slack.go
@@ -11,15 +11,47 @@ import (
 	"github.com/nlopes/slack/slackutilsx"
 )
 
-func sendToSlack(format string, args ...interface{}) {
-	token := config.Slack.Token
-	channelName := config.Slack.Channel
-	user := config.Slack.User
+// Use getSlackClient() to access it with lazy initialize feature.
+var slackClient *slack.Client = nil
 
-	if token == "" {
-		println("no slack token")
+var slackMemberInit = false
+var slackMembers = map[string]string{}
+
+func getSlackClient() *slack.Client {
+	if slackClient == nil {
+		slackClient = slack.New(config.Slack.Token)
+	}
+	return slackClient
+}
+
+func initSlackMemberCache() {
+	if slackMemberInit {
 		return
 	}
+	users, err := getSlackClient().GetUsers()
+	perror(err)
+	if len(users) == 0 {
+		perror(fmt.Errorf("cannot retrieve slack user list. slack app must be granted `users:read` and `users:read.email` permission"))
+	}
+
+	for _, user := range users {
+		slackMembers[strings.ToLower(user.Profile.Email)] = user.ID
+	}
+	slackMemberInit = true
+}
+
+func buildSlackMention(email string) string {
+	initSlackMemberCache()
+	id, ok := slackMembers[strings.ToLower(email)]
+	if !ok {
+		return slackutilsx.EscapeMessage(email)
+	}
+	return fmt.Sprintf("<@%s>", id)
+}
+
+func sendToSlack(format string, args ...interface{}) {
+	channelName := config.Slack.Channel
+	user := config.Slack.User
 
 	if channelName == "" {
 		println("no slack channel name")
@@ -30,8 +62,7 @@ func sendToSlack(format string, args ...interface{}) {
 		channelName = "#" + channelName
 	}
 
-	api := slack.New(token)
-	_, _, err := api.PostMessage(channelName,
+	_, _, err := getSlackClient().PostMessage(channelName,
 		slack.MsgOptionUser(user),
 		slack.MsgOptionText(fmt.Sprintf(format, args...), false))
 	if err != nil {
@@ -47,6 +78,7 @@ func formatSectionForSlackOutput(buf *bytes.Buffer, title string, description st
 func formatGitHubIssueForSlackOutput(issue github.Issue) string {
 	isFromTeam := false
 	login := issue.GetUser().GetLogin()
+
 	for _, id := range allMembers {
 		if strings.EqualFold(id, login) {
 			isFromTeam = true
@@ -57,10 +89,15 @@ func formatGitHubIssueForSlackOutput(issue github.Issue) string {
 	if !isFromTeam {
 		tp = " _(Community)_"
 	}
+	var closed string
+	if issue.GetState() == "closed" {
+		closed = " _(Closed)_"
+	}
 
 	s := fmt.Sprintf(
-		"[ %s ]%s <%s|%s> by @%s",
+		"[ %s ]%s%s <%s|%s> by @%s",
 		slackutilsx.EscapeMessage(regexRepo.FindStringSubmatch(issue.GetHTMLURL())[1]),
+		slackutilsx.EscapeMessage(closed),
 		slackutilsx.EscapeMessage(tp),
 		issue.GetHTMLURL(),
 		slackutilsx.EscapeMessage(issue.GetTitle()),
@@ -87,12 +124,17 @@ func formatJiraIssueForSlackOutput(issue jira.Issue) string {
 	if issue.Fields != nil && issue.Fields.Priority != nil {
 		priority = issue.Fields.Priority.Name
 	}
+	assignment := ""
+	if issue.Fields != nil && issue.Fields.Assignee != nil {
+		assignment = fmt.Sprintf("assigned to %s", buildSlackMention(issue.Fields.Assignee.EmailAddress))
+	}
 	return fmt.Sprintf(
-		"[ %s / %s ] <%s|%s>",
+		"[ %s / %s ] <%s|%s> %s",
 		slackutilsx.EscapeMessage(status),
 		slackutilsx.EscapeMessage(priority),
 		link,
 		slackutilsx.EscapeMessage(issue.Fields.Summary),
+		assignment,
 	)
 }
 

--- a/slack.go
+++ b/slack.go
@@ -58,7 +58,14 @@ func formatGitHubIssueForSlackOutput(issue github.Issue) string {
 		tp = " _(Community)_"
 	}
 
-	s := fmt.Sprintf("[ %s ]%s <%s|%s> by @%s", regexRepo.FindStringSubmatch(issue.GetHTMLURL())[1], tp, issue.GetHTMLURL(), slackutilsx.EscapeMessage(issue.GetTitle()), issue.GetUser().GetLogin())
+	s := fmt.Sprintf(
+		"[ %s ]%s <%s|%s> by @%s",
+		slackutilsx.EscapeMessage(regexRepo.FindStringSubmatch(issue.GetHTMLURL())[1]),
+		slackutilsx.EscapeMessage(tp),
+		issue.GetHTMLURL(),
+		slackutilsx.EscapeMessage(issue.GetTitle()),
+		slackutilsx.EscapeMessage(issue.GetUser().GetLogin()),
+	)
 
 	if issue.Assignees != nil && len(issue.Assignees) > 0 {
 		s += fmt.Sprintf(", assigned to")
@@ -80,7 +87,13 @@ func formatJiraIssueForSlackOutput(issue jira.Issue) string {
 	if issue.Fields != nil && issue.Fields.Priority != nil {
 		priority = issue.Fields.Priority.Name
 	}
-	return fmt.Sprintf("[ %s / %s ] <%s|%s>", status, priority, link, issue.Fields.Summary)
+	return fmt.Sprintf(
+		"[ %s / %s ] <%s|%s>",
+		slackutilsx.EscapeMessage(status),
+		slackutilsx.EscapeMessage(priority),
+		link,
+		slackutilsx.EscapeMessage(issue.Fields.Summary),
+	)
 }
 
 func formatGitHubIssuesForSlackOutput(buf *bytes.Buffer, issues []github.Issue) {

--- a/weekly.go
+++ b/weekly.go
@@ -6,7 +6,6 @@ import (
 	"html"
 
 	"github.com/andygrunwald/go-jira"
-
 	"github.com/google/go-github/github"
 	"github.com/spf13/cobra"
 )
@@ -48,7 +47,7 @@ func genUserPage(buf *bytes.Buffer, m Member, curSprint jira.Sprint, nextSprint 
 func genReviewPullReques(buf *bytes.Buffer, user, start, end string) {
 	buf.WriteString("<h3>Review PR</h3>")
 
-	issues := getReviewPullRequests(user, start, end)
+	issues := getReviewPullRequests(user, start, &end)
 	if len(issues) == 0 {
 		return
 	}
@@ -107,7 +106,7 @@ func htmlFormatIssues(buf *bytes.Buffer, title string, issues []github.Issue) {
 }
 
 func genCreatedIssues(buf *bytes.Buffer, title string, start, end string) {
-	issues := getCreatedIssues(start, end)
+	issues := getCreatedIssues(start, &end)
 	htmlFormatIssues(buf, title, issues)
 }
 


### PR DESCRIPTION
1. Add "(Community)" tag for community GitHub issues
2. Query GitHub issues for precisely -24 hours
3. Polish GitHub issues output format
4. Provide New OnCalls (New on calls in last 24 hours)
5. Provide Inactive OnCalls (Highest priority on calls inactive >= 3 days)
